### PR TITLE
Adjust map layout

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="flex flex-col md:flex-row flex-grow h-full">
     <recolto-calculator
-      class="w-full md:w-1/2 z-[1002] overflow-auto md:max-h-full"
+      class="w-full md:w-[32rem] md:max-w-[32rem] z-[1002] overflow-auto md:max-h-full"
       :class="{
         'h-[30rem] md:h-full scrolling-auto overflow-auto': currentStep === 2
       }"
@@ -21,7 +21,7 @@
       @disable-draw="drawEnabled = undefined"
     />
     <recolto-map
-      class="w-full md:w-1/2 h-64 md:h-full"
+      class="flex-1 h-64 md:h-full"
       :draw-enabled="drawEnabled"
       :center="center"
       @polygon:created="onPolygonCreated"


### PR DESCRIPTION
## Summary
- set calculator component width on large screens
- make map take remaining space

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684bebd405b08330bbd5ff601e5b2ae2