### PR TITLE
Add table layout form

### DIFF
--- a/components/tableCalculator/TableForm.vue
+++ b/components/tableCalculator/TableForm.vue
@@ -1,0 +1,81 @@
+<template>
+  <table class="w-full table-auto text-white bg-primary/80 rounded-md">
+    <tbody>
+      <tr>
+        <td>
+          <Step1
+            :roof-surface="roofSurface"
+            v-model:roof-type="roofType"
+            v-model:has-sewage-system="selectedSewageSystem"
+            @new-center="$emit('newCenter', $event)"
+            @draw-roof="$emit('drawRoof', $event)"
+          />
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <Step2
+            v-model:surface-garden="surfaceGarden"
+            v-model:surface-vegetable="surfaceVegetable"
+            v-model:other-needs="otherNeeds"
+            v-model:toilets-connected="toiletsConnected"
+            v-model:washing-machine-connected="washingMachineConnected"
+            v-model:resident-number="residentNumber"
+            :surface-garden-drawn="surfaceGardenDrawn"
+            :surface-vegetable-drawn="surfaceVegetableDrawn"
+            :force-reset-input="forceResetInput"
+            @draw-water-usage="$emit('drawWaterUsage', $event)"
+          />
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <Step3
+            :roof-surface="roofSurface"
+            :roof-absorbtion-coeff="roofType.coeff"
+            :roof-center="roofCenter"
+            :garden-surface="surfaceGarden"
+            :vegetable-surface="surfaceVegetable"
+            :other-needs="otherNeeds"
+            :toilets-connected="toiletsConnected"
+            :washing-machine-connected="washingMachineConnected"
+            :resident-number="residentNumber"
+            :has-sewage-system="selectedSewageSystem"
+          />
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</template>
+
+<script setup lang="ts">
+import L from 'leaflet'
+import { RoofType } from '~/declaration'
+import Step1, { roofTypeList } from '../calculator/Step1.vue'
+import Step2 from '../calculator/Step2.vue'
+import Step3 from '../calculator/Step3.vue'
+
+const emit = defineEmits([
+  'drawRoof',
+  'drawWaterUsage',
+  'newCenter'
+])
+
+const props = defineProps<{
+  roofSurface: number
+  roofCenter?: L.LatLng | L.LatLngLiteral
+  surfaceGardenDrawn: number
+  surfaceVegetableDrawn: number
+  forceResetInput: null | { area: 'garden' | 'vegetable'; newValue: number }
+}>()
+
+const roofType = ref<RoofType>(roofTypeList[0])
+const selectedSewageSystem = ref(true)
+const surfaceGarden = ref(0)
+const surfaceVegetable = ref(0)
+const otherNeeds = ref(0)
+const toiletsConnected = ref(false)
+const washingMachineConnected = ref(false)
+const residentNumber = ref(0)
+</script>
+

--- a/pages/table.vue
+++ b/pages/table.vue
@@ -1,0 +1,109 @@
+<template>
+  <div class="flex flex-col md:flex-row flex-grow h-full">
+    <TableForm
+      class="w-full md:w-1/2 md:max-w-none z-[1002] overflow-auto md:max-h-full"
+      :roof-surface="roofSurface"
+      :roof-center="roofCenter"
+      :surface-garden-drawn="surfaceGardenDrawn"
+      :surface-vegetable-drawn="surfaceVegetableDrawn"
+      :force-reset-input="forceResetInput"
+      @draw-roof="allowDrawMap($event)"
+      @draw-water-usage="allowDrawMap($event)"
+      @new-center="center = $event"
+    />
+    <RecoltoMap
+      class="w-full md:w-1/2 h-64 md:h-full"
+      :draw-enabled="drawEnabled"
+      :center="center"
+      @polygon:created="onPolygonCreated"
+      @polygon:edited="onPolygonEdited"
+      @polygon:deleted="onPolygonDeleted"
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+import L from 'leaflet'
+import RecoltoMap from '~/components/map/RecoltoMap.vue'
+import TableForm from '~/components/tableCalculator/TableForm.vue'
+
+definePageMeta({
+  layout: 'app',
+})
+
+const roofCenter = ref<L.LatLng | L.LatLngLiteral>()
+const roofSurface = ref(0)
+
+const surfaceGardenDrawn = ref(0)
+const surfaceVegetableDrawn = ref(0)
+
+const forceResetInput = ref<null | { area: 'garden' | 'vegetable'; newValue: number }>(null)
+
+const drawEnabled = ref<{ area: 'roof' | 'garden' | 'vegetable' | 'allUsage'; action?: 'draw' | 'clear' }>()
+
+const allowDrawMap = (data?: { area: 'roof' | 'garden' | 'vegetable' | 'allUsage'; action?: 'draw' | 'clear' }) => {
+  if (!data) {
+    drawEnabled.value = undefined
+    return
+  }
+  if (data.action === 'clear' && data.area === 'garden') {
+    surfaceGardenDrawn.value = 0
+  }
+  if (data.action === 'clear' && data.area === 'vegetable') {
+    surfaceVegetableDrawn.value = 0
+  }
+  if (data.action === 'clear' && data.area === 'allUsage') {
+    surfaceGardenDrawn.value = 0
+    surfaceVegetableDrawn.value = 0
+  }
+  drawEnabled.value = data
+}
+
+const center = ref<{ latlng: L.LatLng | L.LatLngLiteral; accuracy?: number }>()
+
+function onPolygonCreated(geodesicArea: number, newCentroid: L.LatLng | L.LatLngLiteral, area: string) {
+  if (area === 'roof') {
+    roofCenter.value = newCentroid
+    roofSurface.value = Number(geodesicArea.toFixed(2))
+  }
+  if (area === 'garden') {
+    surfaceGardenDrawn.value = Number((surfaceGardenDrawn.value + geodesicArea).toFixed(2))
+  }
+  if (area === 'vegetable') {
+    surfaceVegetableDrawn.value = Number((surfaceVegetableDrawn.value + geodesicArea).toFixed(2))
+  }
+}
+
+function onPolygonEdited(totalGeodesicArea: number, area: string) {
+  if (area === 'roof') {
+    roofSurface.value = Number(totalGeodesicArea.toFixed(2))
+  }
+  if (area === 'garden') {
+    surfaceGardenDrawn.value = Number(totalGeodesicArea.toFixed(2))
+  }
+  if (area === 'vegetable') {
+    surfaceVegetableDrawn.value = Number(totalGeodesicArea.toFixed(2))
+  }
+}
+
+const onPolygonDeleted = (geodesicArea: number, area: string) => {
+  if (area === 'garden') {
+    surfaceGardenDrawn.value = Number((surfaceGardenDrawn.value - geodesicArea).toFixed(2))
+    forceResetInput.value = {
+      area: 'garden',
+      newValue: Number((surfaceGardenDrawn.value - geodesicArea).toFixed(2)),
+    }
+  }
+  if (area === 'vegetable') {
+    surfaceVegetableDrawn.value = Number((surfaceVegetableDrawn.value - geodesicArea).toFixed(2))
+    forceResetInput.value = {
+      area: 'vegetable',
+      newValue: Number((surfaceVegetableDrawn.value - geodesicArea).toFixed(2)),
+    }
+  }
+}
+
+useHead({
+  title: "Récolt'Ô | Table Calculator",
+})
+</script>


### PR DESCRIPTION
## Summary
- create `TableForm` component that embeds existing calculator steps in a table
- add new `table` page using the new component

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684c2836941883309d76a22357a8cd1b