### PR TITLE
Use TableForm on index page

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="flex flex-col md:flex-row flex-grow h-full">
-    <FlexForm
+    <TableForm
       class="w-full md:w-1/2 md:max-w-none z-[1002] overflow-auto md:max-h-full"
       :roof-surface="roofSurface"
       :roof-center="roofCenter"
@@ -25,7 +25,7 @@
 <script setup lang="ts">
 import L from "leaflet";
 import RecoltoMap from "../components/map/RecoltoMap.vue";
-import FlexForm from "~/components/FlexForm.vue";
+import TableForm from "~/components/tableCalculator/TableForm.vue";
 
 definePageMeta({
   layout: "app",


### PR DESCRIPTION
## Summary
- replace FlexForm with TableForm on the main calculator page

## Testing
- `npm run build` *(fails: nuxt not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c2a32215c8330999845ab2a1ac1fb