### PR TITLE
Enable all calculator steps on single page

### DIFF
--- a/components/calculator/RecoltoCalculator.vue
+++ b/components/calculator/RecoltoCalculator.vue
@@ -3,59 +3,14 @@
     class="w-full max-w-full md:w-[28rem] md:max-w-[28rem] lg:w-[32rem] lg:max-w-[32rem] text-white p-4 md:p-6 bg-primary/80 rounded-t-md md:rounded-md"
   >
     <div class="flex flex-col">
-      <header class="mb-4 hidden md:block">
-        <h2 class="text-center mb-4">
-          {{ t("calculator.steps") }}
-        </h2>
-
-        <div class="grid grid-cols-3 justify-items-stretch">
-          <button
-            v-for="(step, index) in steps"
-            :key="step.value"
-            @click="changeStep(index)"
-            class="min-w-full w-full md:w-24 text-xs md:text-base text-center mx-auto rounded-xl p-2 disabled:text-gray disabled:bg-gray disabled:cursor-not-allowed flex flex-col items-center content-end"
-            :class="{
-              'bg-white text-purple font-semibold dark:bg-slate-700 dark:text-white': currentStep === index,
-            }"
-            :disabled="currentStep < index "
-          >
-            <svg
-              v-if="step.icon === 'faucet_drip'"
-              :class="[
-                currentStep === index ? 'stroke-purple dark:stroke-white' : 'stroke-white dark:stroke-white'
-              ]"
-              class="w-6 h-6 m-auto"
-              xmlns="http://www.w3.org/2000/svg"
-              height="8em"
-              viewBox="0 0 512 512"
-              fill="transparent"
-              stroke-width="1.8rem"
-            ><!--! Font Awesome Free 6.4.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2023 Fonticons, Inc. -->
-              <path
-                d="M224 0c17.7 0 32 14.3 32 32V44l96-12c17.7 0 32 14.3 32 32s-14.3 32-32 32L256 84l-31-3.9-1-.1-1 .1L192 84 96 96C78.3 96 64 81.7 64 64s14.3-32 32-32l96 12V32c0-17.7 14.3-32 32-32zM0 224c0-17.7 14.3-32 32-32h96l22.6-22.6c6-6 14.1-9.4 22.6-9.4H192V116.2l32-4 32 4V160h18.7c8.5 0 16.6 3.4 22.6 9.4L320 192h32c88.4 0 160 71.6 160 160c0 17.7-14.3 32-32 32H416c-17.7 0-32-14.3-32-32s-14.3-32-32-32H315.9c-20.2 29-53.9 48-91.9 48s-71.7-19-91.9-48H32c-17.7 0-32-14.3-32-32V224zM436.8 423.4c1.9-4.5 6.3-7.4 11.2-7.4s9.2 2.9 11.2 7.4l18.2 42.4c1.8 4.1 2.7 8.6 2.7 13.1V480c0 17.7-14.3 32-32 32s-32-14.3-32-32v-1.2c0-4.5 .9-8.9 2.7-13.1l18.2-42.4z"
-              />
-            </svg>
-            <UIcon
-              v-else
-              :name="step.icon"
-              class="h-6 w-6"
-            />
-            <span>{{ step.label }}</span>
-          </button>
-        </div>
-      </header>
-
       <Step1
-        v-if="currentStep === 0"
         :roof-surface="roofSurface"
         v-model:roof-type="roofType"
         v-model:has-sewage-system="selectedSewageSystem"
-        @next="changeStep(1)"
         @new-center="$emit('newCenter', $event)"
         @draw-roof="$emit('drawRoof', $event)"
       />
       <Step2
-        v-else-if="currentStep === 1"
         v-model:surface-garden="surfaceGarden"
         v-model:surface-vegetable="surfaceVegetable"
         v-model:other-needs="otherNeeds"
@@ -66,12 +21,8 @@
         :surface-vegetable-drawn="surfaceVegetableDrawn"
         :force-reset-input="forceResetInput"
         @draw-water-usage="$emit('drawWaterUsage', $event)"
-        @next="changeStep(2)"
-        @previous="changeStep(0)"
       />
-
       <Step3
-        v-else-if="currentStep === 2"
         :roof-surface="roofSurface"
         :roof-absorbtion-coeff="roofType.coeff"
         :roof-center="roofCenter"
@@ -82,7 +33,6 @@
         :washing-machine-connected="washingMachineConnected"
         :resident-number="residentNumber"
         :has-sewage-system="selectedSewageSystem"
-        @previous="changeStep(1)"
       />
     </div>
   </div>
@@ -99,27 +49,10 @@ const { t } = useI18n();
 const emit = defineEmits([
   "drawRoof",
   "drawWaterUsage",
-  "disableDraw",
   "newCenter",
 ]);
 
-const steps = [
-  {
-    value: 1,
-    label: t("calculator.roof"),
-    icon: "i-heroicons-home",
-  }, {
-    value: 2,
-    label: t("calculator.habits"),
-    icon: "faucet_drip",
-  }, {
-    value: 3,
-    label: t("calculator.results"),
-    icon: "i-heroicons-chart-bar-square",
-  },
-];
 
-const currentStep = defineModel<number>('currentStep', {required: true})
 const roofType = ref<RoofType>(roofTypeList[0])
 const selectedSewageSystem = ref<boolean>(true)
 const surfaceGarden = ref<number>(0)
@@ -138,10 +71,5 @@ defineProps<{
   surfaceVegetableDrawn: number,
   forceResetInput: null | { area: "garden" | "vegetable", newValue: number },
 }>();
-
-const changeStep = (step: number) => {
-  currentStep.value = step
-  emit("disableDraw");
-};
 
 </script>

--- a/components/calculator/Step1.vue
+++ b/components/calculator/Step1.vue
@@ -92,14 +92,6 @@
     >
       {{ t("calculator.redraw") }}
     </UButton>
-    <UButton
-      @click="$emit('next')"
-      class="sm:h-12 sm:w-56 mx-auto my-2 bg-purple border border-white flex justify-center items-center disabled:bg-purple-300 ring-purple hover:bg-purple-900 dark:bg-purple dark:text-white dark:hover:bg-purple-900"
-      :disabled="!props.roofSurface"
-      :title="!props.roofSurface ? 'Vous devez sélectionner une adresse' : ''"
-    >
-      {{ t("calculator.next_step") }}
-    </UButton>
   </div>
 </template>
 
@@ -124,7 +116,6 @@ const emit = defineEmits([
   "newCenter",
   "select",
   "drawRoof",
-  "next",
 ]);
 
 const roofType = defineModel<RoofType>('roofType', { required: true })

--- a/components/calculator/Step2.vue
+++ b/components/calculator/Step2.vue
@@ -154,30 +154,7 @@
       </div>
     </UsageAccordion>
 
-    <div class="flex flex-row mt-2 justify-between">
-      <UButton
-        size="xl"
-        color="white"
-        variant="outline"
-        :trailing="false"
-        @click="$emit('previous')"
-        class="sm:h-12 sm:w-48 my-2 flex justify-center items-center"
-        :ui="{ variant: { outline: 'shadow-sm bg-transparent text-white-900 dark:text-white ring-1 ring-inset ring-white dark:ring-white-400 focus:ring-2 focus:ring-purple dark:focus:ring-white hover:bg-purple' }}"
-      >
-        {{ t("calculator.previous_step") }}
-      </UButton>
-      <UButton
-        icon="i-heroicons-calculator"
-        size="xl"
-        color="white"
-        variant="outline"
-        :trailing="false"
-        @click="$emit('next')"
-        class="sm:h-12 sm:w-48 my-2 bg-purple border border-white flex justify-center items-center disabled:bg-purple-300 ring-purple hover:bg-purple-900"
-      >
-        {{ t("step2.compute") }}
-      </UButton>
-    </div>
+
 
   </SubStep>
 </template>
@@ -189,7 +166,7 @@ import UsageAccordion from "./UsageAccordion.vue";
 
 const { t } = useI18n();
 
-const emit = defineEmits(["next", "drawWaterUsage", "previous"]);
+const emit = defineEmits(["drawWaterUsage"]);
 
 const surfaceGarden = defineModel<number>('surfaceGarden', {required: true})
 const surfaceVegetable = defineModel<number>('surfaceVegetable', {required: true})

--- a/components/calculator/Step3.vue
+++ b/components/calculator/Step3.vue
@@ -1,5 +1,6 @@
 <template>
   <SubStep
+    v-if="props.roofCenter"
     :number="5"
     :title="t('step3.estimation')"
   >
@@ -175,7 +176,8 @@ watch(props, async (props) => {
   loading.value = true;
 
   if (!props.roofCenter) {
-    throw 'No centroid !'
+    loading.value = false;
+    return;
   }
 
   rainData.value = await getRainData(props.roofCenter)

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -3,8 +3,6 @@
     <div class="md:w-1/2 flex">
       <recolto-calculator
         class="w-full overflow-auto"
-        :class="{ 'h-[30rem]': currentStep === 2 }"
-        v-model:current-step="currentStep"
         :roof-surface="roofSurface"
         :roof-center="roofCenter"
         :surface-garden-drawn="surfaceGardenDrawn"
@@ -13,7 +11,6 @@
         @newCenter="($e) => center = $e"
         @draw-roof="allowDrawMap($event)"
         @draw-water-usage="allowDrawMap($event)"
-        @disable-draw="drawEnabled = undefined"
       />
     </div>
     <div class="md:w-1/2 order-2 md:order-none">
@@ -56,8 +53,6 @@ const forceResetInput= ref<null | {
   area: "garden" | "vegetable",
   newValue: number
 }>(null);
-
-const currentStep = ref(0);
 
 const drawEnabled = ref<{ area: "roof" | "garden" | "vegetable" | "allUsage", action?: "draw" | "clear" }>();
 


### PR DESCRIPTION
## Summary
- remove step navigation from calculator component and show all steps
- simplify step child components
- compute step 3 only when roof is drawn
- update main page accordingly

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6850008d34a88330882a42cc45fdd47f