### PR TITLE
Enlarge form width

### DIFF
--- a/components/calculator/RecoltoCalculator.vue
+++ b/components/calculator/RecoltoCalculator.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="w-full max-w-full md:w-[28rem] md:max-w-[28rem] lg:w-[32rem] lg:max-w-[32rem] text-white p-4 md:p-6 bg-primary/80 rounded-t-md md:rounded-md"
+    class="w-full max-w-full text-white p-4 md:p-6 bg-primary/80 rounded-t-md md:rounded-md"
   >
     <div class="flex flex-col">
       <Step1

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -2,7 +2,7 @@
   <div class="flex flex-col md:flex-row flex-grow">
     <div class="md:w-1/2 flex">
       <recolto-calculator
-        class="w-full overflow-auto"
+        class="w-full"
         :roof-surface="roofSurface"
         :roof-center="roofCenter"
         :surface-garden-drawn="surfaceGardenDrawn"


### PR DESCRIPTION
## Summary
- expand width of the Recolto form container so it fills its column
- remove internal overflow from index page

## Testing
- `npm run build` *(fails: missing dependencies?)*

------
https://chatgpt.com/codex/tasks/task_e_685004db50a08330ab28f659d7e8b02d